### PR TITLE
Fix depreciated .editor call in keymaps.cson

### DIFF
--- a/keymaps/expand-selection-to-quotes.cson
+++ b/keymaps/expand-selection-to-quotes.cson
@@ -1,5 +1,5 @@
-'atom-text-editor.editor.editor':
+'atom-text-editor':
   "ctrl-'": 'expand-selection-to-quotes:toggle'
 
-'.platform-darwin atom-text-editor.editor.editor':
+'.platform-darwin atom-text-editor':
   'cmd-\'': 'expand-selection-to-quotes:toggle'


### PR DESCRIPTION
Hi there,

I was getting a depreciation message for the `keymaps.cson` file related to the use of the `.editor` class. I deleted the trailing `.editor.editor` calls in the keymaps file and tested the package on Linux and it seems to still be working just fine, but without the depreciation message.

Cheers.
